### PR TITLE
add: Tips to README with common `rg` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ By default, `rg` does not search hidden files. If you want to edit hidden files 
     ...
 ```
 
+### Tip - recursion limit
+
+`rg` does not have a directory recursion limit. This means that if you start your `nvim` instance from your `~` folder (or any folder that has many subfolder layers) `rg-cmp` could considerably slow down your system. To set a recursion limit to `n`, add the flag `--max-depth n` to `additional_arguments`. Your configuration could then look like this:
+
+
+```
+    ...
+    {
+        name = 'rg',
+        option = {additional_arguments = '--max-depth 4'},
+    }
+    ...
+```
+
 ## Screenshot
 
 ![Screenshot](https://user-images.githubusercontent.com/12900252/143555260-8567fb04-eea6-4a73-a1dc-d36d4df8cb64.png)

--- a/README.md
+++ b/README.md
@@ -48,33 +48,6 @@ require'cmp'.setup {
 
 For more options see `:help cmp-rg`
 
-### Tip - hidden files
-
-By default, `rg` does not search hidden files. If you want to edit hidden files (dotfiles) and see the output of the `cmp-rg` completion source, you should pass the flag `--hidden` to `rg`. Your configuration could then look like this:
-
-```
-    ...
-    {
-        name = 'rg',
-        option = {additional_arguments = '--hidden'},
-    }
-    ...
-```
-
-### Tip - recursion limit
-
-`rg` does not have a directory recursion limit. This means that if you start your `nvim` instance from your `~` folder (or any folder that has many subfolder layers) `rg-cmp` could considerably slow down your system. To set a recursion limit to `n`, add the flag `--max-depth n` to `additional_arguments`. Your configuration could then look like this:
-
-
-```
-    ...
-    {
-        name = 'rg',
-        option = {additional_arguments = '--max-depth 4'},
-    }
-    ...
-```
-
 ## Screenshot
 
 ![Screenshot](https://user-images.githubusercontent.com/12900252/143555260-8567fb04-eea6-4a73-a1dc-d36d4df8cb64.png)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ require'cmp'.setup {
 
 For more options see `:help cmp-rg`
 
+### Tip - hidden files
+
+By default, `rg` does not search hidden files. If you want to edit hidden files (dotfiles) and see the output of the `cmp-rg` completion source, you should pass the flag `--hidden` to `rg`. Your configuration could then look like this:
+
+```
+    ...
+    {
+        name = 'rg',
+        option = {additional_arguments = '--hidden'},
+    }
+    ...
+```
+
 ## Screenshot
 
 ![Screenshot](https://user-images.githubusercontent.com/12900252/143555260-8567fb04-eea6-4a73-a1dc-d36d4df8cb64.png)

--- a/doc/cmp-rg.txt
+++ b/doc/cmp-rg.txt
@@ -32,7 +32,14 @@ additional_arguments                             *cmp-rg-additional_arguments*
     Example: >
 
         { name = 'rg', option = { additional_arguments = "--ignore-case" } }
+<
+    Search in hidden files (starting with a `.`): >
+        { name = 'rg', option = { additional_arguments = "--hidden" } }
+<
 
+    Reduce the level of recursion into directories: >
+        { name = 'rg', option = { additional_arguments = "--max-depth 4" } }
+<
 
 ------------------------------------------------------------------------------
 cwd                                                               *cmp-rg-cwd*


### PR DESCRIPTION
- add: tip for hidden files
- add: tip for recursion limit

These may be quite commonly desired by users. I think they could be a part of the README.
