### PR TITLE
Option to only run rg completion if in a git directory

### DIFF
--- a/doc/cmp-rg.txt
+++ b/doc/cmp-rg.txt
@@ -37,10 +37,13 @@ additional_arguments                             *cmp-rg-additional_arguments*
 
         { name = 'rg', option = { additional_arguments = "--hidden" } }
 <
-
     Reduce the level of recursion into directories: >
 
         { name = 'rg', option = { additional_arguments = "--max-depth 4" } }
+
+    Only run completion if in git repo:
+
+        { name = 'rg', option = { git_check = true } }
 <
 
 ------------------------------------------------------------------------------
@@ -99,6 +102,17 @@ debug                                                           *cmp-rg-debug*
     Example: >
 
         { name = 'rg', option = { debug = true } }
+
+------------------------------------------------------------------------------
+git_check                                                           *cmp-rg-git-check*
+
+    Prevent completion if not in git repo
+
+    Default: false                                                           ~
+
+    Example: >
+
+        { name = 'rg', option = { git_check = true } }
 
 ==============================================================================
  2. SETUP                                                       *cmp-rg-setup*

--- a/doc/cmp-rg.txt
+++ b/doc/cmp-rg.txt
@@ -40,8 +40,8 @@ additional_arguments                             *cmp-rg-additional_arguments*
     Reduce the level of recursion into directories: >
 
         { name = 'rg', option = { additional_arguments = "--max-depth 4" } }
-
-    Only run completion if in git repo:
+<
+    Only run completion if in git repo: >
 
         { name = 'rg', option = { git_check = true } }
 <


### PR DESCRIPTION
There is a chance with `cmp-rg` to accidentally run a large completion job (even with `max-depth` set to something reasonable) 
if you are in a directory that has lots of sub-directories.

If wanted this option would limit completion to only occur if you are currently in a git directory. 
Which would lower the risk of freezing if a user opened neovim in their `~/git_projects` folder, which at least for me with a max-depth of 4 accounts for 8259 directories