### PR TITLE
fix documentation interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lua/cmp-rg/init.lua
+++ b/lua/cmp-rg/init.lua
@@ -1,14 +1,16 @@
+require "cmp-rg.types"
+
+---@class Source
+---@field public running_job_id number
+---@field public json_decode fun(s: string): rg.Message
+---@field public timer any
 local source = {}
 
 source.new = function()
-    local json_decode = vim.fn.json_decode
-    if vim.fn.has "nvim-0.6" == 1 then
-        json_decode = vim.json.decode
-    end
     return setmetatable({
         running_job_id = 0,
         timer = vim.loop.new_timer(),
-        json_decode = json_decode,
+        json_decode = vim.fn.has "nvim-0.6" == 1 and vim.json.decode or vim.fn.json_decode,
     }, { __index = source })
 end
 
@@ -24,65 +26,90 @@ source.complete = function(self, request, callback)
     end
     local seen = {}
     local items = {}
-    local context = {}
-    local documentation_to_add = 0
 
     local function on_event(job_id, data, event)
         if event == "stdout" then
-            for _, entry in ipairs(data) do
-                if entry ~= "" then
-                    local ok, result = pcall(self.json_decode, entry)
-                    if
-                        not ok
-                        or result.type == "end"
-                        or (vim.tbl_contains({ "context", "match" }, result.type) and not result.data.lines.text)
-                    then
-                        context = {}
-                        documentation_to_add = 0
-                    elseif result.type == "context" then
-                        local documentation = result.data.lines.text:gsub("\n", "")
-                        table.insert(context, documentation)
-                        if documentation_to_add > 0 then
-                            local d = items[#items].documentation
-                            table.insert(d, documentation)
-                            documentation_to_add = documentation_to_add - 1
+            ---@type (string|rg.Message)[]
+            local messages = data
 
-                            if documentation_to_add == 0 then
-                                local min_indent = 1e309
-                                for i = 4, #d, 1 do
-                                    if d[i] ~= "" then
-                                        local _, indent = string.find(d[i], "^%s+")
-                                        min_indent = math.min(min_indent, indent or 0)
-                                    end
+            --- Get a message that has `data.lines.text`.
+            --- If message is not yet decoded, decode it and update `messages` table.
+            --- `\n` at the end of `data.lines.text` is removed.
+            ---@param index number
+            ---@return rg.Message|nil
+            local function get_message_with_lines(index)
+                if index < 1 then
+                    return nil
+                end
+                local m = messages[index]
+                if not m then
+                    return nil
+                end
+                if type(m) == "string" then
+                    local ok, decoded = pcall(self.json_decode, m)
+                    if not ok then
+                        return nil
+                    end
+                    m, messages[index] = decoded, decoded
+                end
+                if m.type ~= "match" and m.type ~= "context" then
+                    return nil
+                end
+                if not m.data.lines.text then
+                    return nil
+                end
+                m.data.lines.text = m.data.lines.text:gsub("\n", "")
+                return m
+            end
+
+            for current = 1, #data, 1 do
+                local message = get_message_with_lines(current)
+                if message and message.type == "match" then
+                    local label = message.data.submatches[1].match.text
+                    if label and not seen[label] then
+                        local path = message.data.path.text
+                        local doc_lines = { path, "", "```" }
+                        local doc_body = {}
+                        if context_before > 0 then
+                            for j = current - context_before, current - 1, 1 do
+                                local before = get_message_with_lines(j)
+                                if before then
+                                    table.insert(doc_body, before.data.lines.text)
                                 end
-                                for i = 4, #d, 1 do
-                                    d[i] = d[i]:sub(min_indent)
-                                end
-                                table.insert(d, "```")
                             end
                         end
-                    elseif result.type == "match" then
-                        local label = result.data.submatches[1].match.text
-                        if label and not seen[label] then
-                            local documentation = { result.data.path.text, "", "```" }
-                            for i = context_before, 0, -1 do
-                                table.insert(documentation, context[i])
+                        table.insert(doc_body, message.data.lines.text .. " <--")
+                        if context_after > 0 then
+                            for k = current + 1, current + context_after, 1 do
+                                local after = get_message_with_lines(k)
+                                if after then
+                                    table.insert(doc_body, after.data.lines.text)
+                                end
                             end
-                            local match_line = result.data.lines.text:gsub("\n", "") .. "  <--"
-                            table.insert(documentation, match_line)
-                            table.insert(items, {
-                                label = label,
-                                documentation = documentation,
-                            })
-                            documentation_to_add = context_after
-                            seen[label] = true
                         end
+
+                        -- shallow indent
+                        local min_indent = math.huge
+                        for _, line in ipairs(doc_body) do
+                            local _, indent = string.find(line, "^%s+")
+                            min_indent = math.min(min_indent, indent or math.huge)
+                        end
+                        for _, line in ipairs(doc_body) do
+                            table.insert(doc_lines, line:sub(min_indent))
+                        end
+
+                        table.insert(doc_lines, "```")
+                        local documentation = {
+                            value = table.concat(doc_lines, "\n"),
+                            kind = "markdown",
+                        }
+                        table.insert(items, {
+                            label = label,
+                            documentation = documentation,
+                        })
+                        seen[label] = true
                     end
                 end
-            end
-            for _, item in ipairs(items) do
-                item.documentation.kind = "markdown"
-                item.documentation.value = table.concat(item.documentation, "\n")
             end
             callback { items = items, isIncomplete = true }
         end

--- a/lua/cmp-rg/init.lua
+++ b/lua/cmp-rg/init.lua
@@ -80,6 +80,10 @@ source.complete = function(self, request, callback)
                     end
                 end
             end
+            for _, item in ipairs(items) do
+                item.documentation.kind = "markdown"
+                item.documentation.value = table.concat(item.documentation, "\n")
+            end
             callback { items = items, isIncomplete = true }
         end
 

--- a/lua/cmp-rg/types.lua
+++ b/lua/cmp-rg/types.lua
@@ -1,0 +1,20 @@
+---@class rg.Message
+---@field public type 'begin'|'match'|'context'|'end'
+---@field public data rg.MessageData
+
+---@class rg.MessageData
+---@field public path       rg.MessageDataPath
+---@field public lines      rg.MessageDataLines|nil
+---@field public submatches rg.MessageSubmatch[]|nil
+
+---@class rg.MessageDataPath
+---@field public text string
+
+---@class rg.MessageDataLines
+---@field public text string
+
+---@class rg.MessageSubmatch
+---@field public match rg.MessageSubmatchMatch
+
+---@class rg.MessageSubmatchMatch
+---@field public text string|nil


### PR DESCRIPTION
nvim-cmp version:
https://github.com/hrsh7th/nvim-cmp/tree/76ba56ce962db88f8ca71c554c568106ca076dc3

cmp-rg version:
[v1.3.6](https://github.com/lukas-reineke/cmp-rg/releases/tag/v1.3.6)

run on:
MacBook Pro (15-inch, 2018)

I encountered following error:

```
Error executing vim.schedule lua callback: ...im/site/pack/packer/start/nvim-cmp/lua/cmp/utils/str.lua:80: attempt to get length of local 'text' (a nil value)
stack traceback:
        ...im/site/pack/packer/start/nvim-cmp/lua/cmp/utils/str.lua:80: in function 'trim'
        ...e/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/entry.lua:446: in function 'get_documentation'
        ...te/pack/packer/start/nvim-cmp/lua/cmp/view/docs_view.lua:42: in function 'open'
        ...re/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/view.lua:238: in function 'callback'
        .../site/pack/packer/start/nvim-cmp/lua/cmp/utils/async.lua:95: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

This seems to happen because `documentation`'s incompatibility.

`documentation` could be one of `lsp.MarkupContent|string|nil`.
And if `documentation` is a table, it must have `kind` and `value` keys.

https://github.com/hrsh7th/nvim-cmp/blob/76ba56ce962db88f8ca71c554c568106ca076dc3/lua/cmp/types/lsp.lua#L188

https://github.com/hrsh7th/nvim-cmp/blob/76ba56ce962db88f8ca71c554c568106ca076dc3/lua/cmp/types/lsp.lua#L143-L145

Currently, `documentation` in this plugin is a table, but it does'nt have those keys, so I added minor changes to have it fit.