### PR TITLE
feat(options): cwd as function with nil for abort

### DIFF
--- a/lua/cmp-rg/init.lua
+++ b/lua/cmp-rg/init.lua
@@ -144,6 +144,15 @@ source.complete = function(self, request, callback)
         0,
         vim.schedule_wrap(function()
             vim.fn.jobstop(self.running_job_id)
+
+            local cwd = request.option.cwd or vim.fn.getcwd()
+            if type(cwd) == "function" then
+                cwd = cwd()
+            end
+            if cwd == nil then
+              return
+            end
+
             self.running_job_id = vim.fn.jobstart(
                 string.format(
                     "rg --heading --json --word-regexp -B %d -A %d --color never %s %s%s%s%s .",
@@ -159,7 +168,7 @@ source.complete = function(self, request, callback)
                     on_stderr = on_event,
                     on_stdout = on_event,
                     on_exit = on_event,
-                    cwd = request.option.cwd or vim.fn.getcwd(),
+                    cwd = cwd,
                 }
             )
         end)


### PR DESCRIPTION
Hello back ! Following the issue, the solution I came with.
Allowing to pass a function as the `cwd`, and when the function returns a `nil`, it should not trigger the rg run.

It can be used as follow:

```lua
require("cmp").setup({
  sources = {
    {
      name = "rg",
      options = {
        cwd = find_root_dir,  -- use rg only if find git in parent dir
      },
    },
  }
}
```