### PR TITLE
fix: Accept 'cmd' shell without exe extension for windows

### DIFF
--- a/lua/cmp-rg/init.lua
+++ b/lua/cmp-rg/init.lua
@@ -6,6 +6,8 @@ require "cmp-rg.types"
 ---@field public timer any
 local source = {}
 
+local is_cmd = string.find(vim.o.shell, "cmd") and true or false
+
 source.new = function()
     local timer = vim.loop.new_timer()
     vim.api.nvim_create_autocmd("VimLeavePre", {
@@ -29,10 +31,7 @@ source.complete = function(self, request, callback)
     local additional_arguments = request.option.additional_arguments or ""
     local context_before = request.option.context_before or 1
     local context_after = request.option.context_after or 3
-    local quote = "'"
-    if string.find(vim.o.shell, "cmd") then
-        quote = '"'
-    end
+    local quote = is_cmd and '"' or "'"
     local seen = {}
     local items = {}
     local chunk_size = 5

--- a/lua/cmp-rg/init.lua
+++ b/lua/cmp-rg/init.lua
@@ -30,7 +30,7 @@ source.complete = function(self, request, callback)
     local context_before = request.option.context_before or 1
     local context_after = request.option.context_after or 3
     local quote = "'"
-    if vim.o.shell == "cmd.exe" then
+    if string.find(vim.o.shell, "cmd") then
         quote = '"'
     end
     local seen = {}


### PR DESCRIPTION
Current implementation requires you to forcefully use the `exe` extension as the value for `shell`, however it is possible to only use `cmd` without extension. Checking if shell contains `cmd` should be fine for ether case.